### PR TITLE
cgimap: Switch from CC BY-SA 2.0 to ODbL 1.0

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -202,7 +202,7 @@ write_map(pqxx::work &w,
     writer.attribute("generator", string(PACKAGE_STRING));
     writer.attribute("copyright",  string("OpenStreetMap and contributors"));
     writer.attribute("attribution", string("http://www.openstreetmap.org/copyright/"));
-    writer.attribute("license", string("http://creativecommons.org/licenses/by-sa/2.0/"));
+    writer.attribute("license", string("http://opendatacommons.org/licenses/odbl/1-0/"));
 
     // bounds element, which seems to be standard in the 
     // main map call.


### PR DESCRIPTION
Change of OSM license for after 12 September 2012 07:00 UTC.
